### PR TITLE
Made modules fourbit and eightbit public.

### DIFF
--- a/src/bus/eightbit.rs
+++ b/src/bus/eightbit.rs
@@ -1,5 +1,5 @@
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
-use embedded_hal::digital::OutputPin;
+use embedded_hal::digital::v2::OutputPin;
 
 use bus::DataBus;
 

--- a/src/bus/eightbit.rs
+++ b/src/bus/eightbit.rs
@@ -149,7 +149,7 @@ impl<
         self.set_bus_bits(byte);
 
         self.en.set_high();
-        delay.delay_ms(2u8);
+        delay.delay_ms(1u8);
         self.en.set_low();
 
         if data {

--- a/src/bus/eightbit.rs
+++ b/src/bus/eightbit.rs
@@ -77,51 +77,51 @@ impl<
         let db7: bool = (0b1000_0000 & data) != 0;
 
         if db0 {
-            self.d0.set_high();
+            let _ = self.d0.set_high();
         } else {
-            self.d0.set_low();
+            let _ = self.d0.set_low();
         }
 
         if db1 {
-            self.d1.set_high();
+            let _ = self.d1.set_high();
         } else {
-            self.d1.set_low();
+            let _ = self.d1.set_low();
         }
 
         if db2 {
-            self.d2.set_high();
+            let _ = self.d2.set_high();
         } else {
-            self.d2.set_low();
+            let _ = self.d2.set_low();
         }
 
         if db3 {
-            self.d3.set_high();
+            let _ = self.d3.set_high();
         } else {
-            self.d3.set_low();
+            let _ = self.d3.set_low();
         }
 
         if db4 {
-            self.d4.set_high();
+            let _ = self.d4.set_high();
         } else {
-            self.d4.set_low();
+            let _ = self.d4.set_low();
         }
 
         if db5 {
-            self.d5.set_high();
+            let _ = self.d5.set_high();
         } else {
-            self.d5.set_low();
+            let _ = self.d5.set_low();
         }
 
         if db6 {
-            self.d6.set_high();
+            let _ = self.d6.set_high();
         } else {
-            self.d6.set_low();
+            let _ = self.d6.set_low();
         }
 
         if db7 {
-            self.d7.set_high();
+            let _ = self.d7.set_high();
         } else {
-            self.d7.set_low();
+            let _ = self.d7.set_low();
         }
     }
 }
@@ -141,19 +141,19 @@ impl<
 {
     fn write<D: DelayUs<u16> + DelayMs<u8>>(&mut self, byte: u8, data: bool, delay: &mut D) {
         if data {
-            self.rs.set_high();
+            let _ = self.rs.set_high();
         } else {
-            self.rs.set_low();
+            let _ = self.rs.set_low();
         }
 
         self.set_bus_bits(byte);
 
-        self.en.set_high();
+        let _ = self.en.set_high();
         delay.delay_ms(1u8);
-        self.en.set_low();
+        let _ = self.en.set_low();
 
         if data {
-            self.rs.set_low();
+            let _ = self.rs.set_low();
         }
     }
     fn init<D: DelayUs<u16> + DelayMs<u8>>(&mut self, entry_mode: u8, delay: &mut D) {

--- a/src/bus/eightbit.rs
+++ b/src/bus/eightbit.rs
@@ -156,4 +156,43 @@ impl<
             self.rs.set_low();
         }
     }
+    fn init<D: DelayUs<u16> + DelayMs<u8>>(&mut self, entry_mode: u8, delay: &mut D) {
+        // Wait for the LCD to wakeup if it was off
+        delay.delay_ms(15u8);
+
+        // Initialize Lcd in 8-bit mode
+        self.write(0b0011_0000, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_ms(5u8);
+
+        // Sets 8-bit operation and enables 5x7 mode for chars
+        self.write(0b0011_1000, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        self.write(0b0000_1110, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        // Clear Display
+        self.write(0b0000_0001, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        // Move the cursor to beginning of first line
+        self.write(0b000_0111, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        // Set entry mode
+        self.write(entry_mode, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+    }
 }

--- a/src/bus/fourbit.rs
+++ b/src/bus/fourbit.rs
@@ -1,5 +1,5 @@
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
-use embedded_hal::digital::OutputPin;
+use embedded_hal::digital::v2::OutputPin;
 
 use bus::DataBus;
 

--- a/src/bus/fourbit.rs
+++ b/src/bus/fourbit.rs
@@ -131,4 +131,49 @@ impl<RS: OutputPin, EN: OutputPin, D4: OutputPin, D5: OutputPin, D6: OutputPin, 
             self.rs.set_low();
         }
     }
+
+    fn init<D: DelayUs<u16> + DelayMs<u8>>(&mut self, entry_mode: u8, delay: &mut D) {
+        // Wait for the LCD to wakeup if it was off
+        delay.delay_ms(15u8);
+
+        // Initialize Lcd in 4-bit mode
+        self.write(0x33, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_ms(5u8);
+
+        // Sets 4-bit operation and enables 5x7 mode for chars
+        self.write(0x32, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        self.write(0x28, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        // Clear Display
+        self.write(0x0E, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        // Move the cursor to beginning of first line
+        self.write(0x01, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        // Set entry mode
+        self.write(entry_mode, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+
+        self.write(0x80, false, delay);
+
+        // Wait for the command to be processed
+        delay.delay_us(100);
+    }
 }

--- a/src/bus/fourbit.rs
+++ b/src/bus/fourbit.rs
@@ -47,27 +47,27 @@ impl<RS: OutputPin, EN: OutputPin, D4: OutputPin, D5: OutputPin, D6: OutputPin, 
         let db3: bool = (0b0000_1000 & data) != 0;
 
         if db0 {
-            self.d4.set_high();
+            let _ = self.d4.set_high();
         } else {
-            self.d4.set_low();
+            let _ = self.d4.set_low();
         }
 
         if db1 {
-            self.d5.set_high();
+            let _ = self.d5.set_high();
         } else {
-            self.d5.set_low();
+            let _ = self.d5.set_low();
         }
 
         if db2 {
-            self.d6.set_high();
+            let _ = self.d6.set_high();
         } else {
-            self.d6.set_low();
+            let _ = self.d6.set_low();
         }
 
         if db3 {
-            self.d7.set_high();
+            let _ = self.d7.set_high();
         } else {
-            self.d7.set_low();
+            let _ = self.d7.set_low();
         }
     }
 
@@ -78,27 +78,27 @@ impl<RS: OutputPin, EN: OutputPin, D4: OutputPin, D5: OutputPin, D6: OutputPin, 
         let db7: bool = (0b1000_0000 & data) != 0;
 
         if db4 {
-            self.d4.set_high();
+            let _ = self.d4.set_high();
         } else {
-            self.d4.set_low();
+            let _ = self.d4.set_low();
         }
 
         if db5 {
-            self.d5.set_high();
+            let _ = self.d5.set_high();
         } else {
-            self.d5.set_low();
+            let _ = self.d5.set_low();
         }
 
         if db6 {
-            self.d6.set_high();
+            let _ = self.d6.set_high();
         } else {
-            self.d6.set_low();
+            let _ = self.d6.set_low();
         }
 
         if db7 {
-            self.d7.set_high();
+            let _ = self.d7.set_high();
         } else {
-            self.d7.set_low();
+            let _ = self.d7.set_low();
         }
     }
 }
@@ -108,27 +108,27 @@ impl<RS: OutputPin, EN: OutputPin, D4: OutputPin, D5: OutputPin, D6: OutputPin, 
 {
     fn write<D: DelayUs<u16> + DelayMs<u8>>(&mut self, byte: u8, data: bool, delay: &mut D) {
         if data {
-            self.rs.set_high();
+            let _ = self.rs.set_high();
         } else {
-            self.rs.set_low();
+            let _ = self.rs.set_low();
         }
 
         self.write_upper_nibble(byte);
 
         // Pulse the enable pin to recieve the upper nibble
-        self.en.set_high();
+        let _ = self.en.set_high();
         delay.delay_ms(2u8);
-        self.en.set_low();
+        let _ = self.en.set_low();
 
         self.write_lower_nibble(byte);
 
         // Pulse the enable pin to recieve the lower nibble
-        self.en.set_high();
+        let _ = self.en.set_high();
         delay.delay_ms(2u8);
-        self.en.set_low();
+        let _ = self.en.set_low();
 
         if data {
-            self.rs.set_low();
+            let _ = self.rs.set_low();
         }
     }
 

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -8,6 +8,7 @@ pub use self::fourbit::FourBitBus;
 
 pub trait DataBus {
     fn write<D: DelayUs<u16> + DelayMs<u8>>(&mut self, byte: u8, data: bool, delay: &mut D);
+    fn init<D: DelayUs<u16> + DelayMs<u8>>(&mut self, entry_mode: u8, delay: &mut D);
 
     // TODO
     // fn read(...)

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -1,7 +1,7 @@
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 
-mod eightbit;
-mod fourbit;
+pub mod eightbit;
+pub mod fourbit;
 
 pub use self::eightbit::EightBitBus;
 pub use self::fourbit::FourBitBus;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate embedded_hal;
 
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::delay::DelayUs;
-use embedded_hal::digital::OutputPin;
+use embedded_hal::digital::v2::OutputPin;
 
 pub mod bus;
 
@@ -37,7 +37,7 @@ pub trait HD44780 {
     fn write_char(&mut self, data: char);
 }
 
-impl Write for HD44780 {
+impl Write for dyn HD44780 {
     fn write_str(&mut self, string: &str) -> Result {
         for c in string.chars() {
             self.write_char(c);
@@ -122,7 +122,7 @@ impl<
 
         hd.bus.init(hd.entry_mode.as_byte(), &mut hd.delay);
 
-        return hd;
+        hd
     }
 }
 
@@ -173,7 +173,7 @@ impl<
 
         hd.bus.init(hd.entry_mode.as_byte(), &mut hd.delay);
 
-        return hd;
+        hd
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use embedded_hal::digital::OutputPin;
 
 pub mod bus;
 
-use bus::{DataBus, EightBitBus, FourBitBus};
+pub use bus::{DataBus, EightBitBus, FourBitBus};
 
 pub mod entry_mode;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl<
             display_mode: DisplayMode::default(),
         };
 
-        hd.init_8bit();
+        hd.bus.init(hd.entry_mode.as_byte(), &mut hd.delay);
 
         return hd;
     }
@@ -146,7 +146,7 @@ impl<
             display_mode: DisplayMode::default(),
         };
 
-        hd.init_4bit();
+        hd.bus.init(hd.entry_mode.as_byte(), &mut hd.delay);
 
         return hd;
     }
@@ -302,94 +302,6 @@ where
 
     fn write_command(&mut self, cmd: u8) {
         self.bus.write(cmd, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-    }
-
-    fn init_4bit(&mut self) {
-        // Wait for the LCD to wakeup if it was off
-        self.delay.delay_ms(15u8);
-
-        // Initialize Lcd in 4-bit mode
-        self.bus.write(0x33, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_ms(5u8);
-
-        // Sets 4-bit operation and enables 5x7 mode for chars
-        self.bus.write(0x32, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        self.bus.write(0x28, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        // Clear Display
-        self.bus.write(0x0E, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        // Move the cursor to beginning of first line
-        self.bus.write(0x01, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        // Set entry mode
-        self.bus
-            .write(self.entry_mode.as_byte(), false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        self.bus.write(0x80, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-    }
-
-    // Follow the 8-bit setup procedure as specified in the HD44780 datasheet
-    fn init_8bit(&mut self) {
-        // Wait for the LCD to wakeup if it was off
-        self.delay.delay_ms(15u8);
-
-        // Initialize Lcd in 8-bit mode
-        self.bus.write(0b0011_0000, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_ms(5u8);
-
-        // Sets 8-bit operation and enables 5x7 mode for chars
-        self.bus.write(0b0011_1000, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        self.bus.write(0b0000_1110, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        // Clear Display
-        self.bus.write(0b0000_0001, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        // Move the cursor to beginning of first line
-        self.bus.write(0b000_0111, false, &mut self.delay);
-
-        // Wait for the command to be processed
-        self.delay.delay_us(100);
-
-        // Set entry mode
-        self.bus
-            .write(self.entry_mode.as_byte(), false, &mut self.delay);
 
         // Wait for the command to be processed
         self.delay.delay_us(100);


### PR DESCRIPTION
This patch makes the modules fourbit and eightbit public, to allow a
user to store the driver into a specific type.

Note that this is necessary to use this crate with the RTFM framework (https://github.com/rtfm-rs/cortex-m-rtfm), where we need to call out the specific type, which isn't possible if these types are private.