### PR TITLE
Derive Debug for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,2 +1,3 @@
+#[derive(Debug)]
 pub struct Error;
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
I was unable to unwrap when using the crate's methods. Debug is required for unwrapping and expecting the error.