### PR TITLE
Move from embassy-traits to embedded-hal-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/hd44780-driver"
 readme = "README.md"
 
 [features]
-async = ["embassy-traits"]
+async = ["embedded-hal-async"]
 
 [dependencies]
 embedded-hal = "0.2.3"
-embassy-traits = { version = "0.0.2", optional = true }
+embedded-hal-async = { version = "1.0.0-rc.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ let mut lcd = HD44780::new_4bit(
 );
 
 // Unshift display and set cursor to 0
-lcd.reset(&mut delay); 
+lcd.reset(&mut delay);
 
 // Clear existing characters
-lcd.clear(&mut delay); 
+lcd.clear(&mut delay);
 
 // Display the following string
 lcd.write_str("Hello, world!", &mut delay);
@@ -59,12 +59,12 @@ lcd.write_str("I'm on line 2!", &mut delay);
 The async API is similar to the sync API. The the major differences are that:
 - The async API requires the `async` feature to use.
 - The async API requires the nightly compiler because of use of unstable features.
-- The async API uses `embassy-traits` rather than `embedded-hal` traits.
+- The async API uses `embedded-hal-async` rather than `embedded-hal` traits.
 
 Embassy provides some implementations of these traits for some MCUs, and provides
-an executor that can execute futures. However, projects implementing `embassy-traits`,
+an executor that can execute futures. However, projects implementing `embedded-hal-async` traits,
 including this project, can run on any executor with any driver, provided such
-executor and driver also implement `embassy-traits`.
+executor and driver also implement `embedded-async-traits`.
 
 ```rust
 use hd44780_driver::non_blocking::HD44780;

--- a/src/entry_mode.rs
+++ b/src/entry_mode.rs
@@ -1,20 +1,16 @@
 /// Determines if the cursor should be incremented or decremented on write
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub enum CursorMode {
+	#[default]
 	Increment,
 	Decrement,
 }
 
-impl Default for CursorMode {
-	fn default() -> CursorMode {
-		CursorMode::Increment
-	}
-}
-
 /// Determines if the screen should be shifted on write
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub enum ShiftMode {
 	Enabled,
+	#[default]
 	Disabled,
 }
 
@@ -25,12 +21,6 @@ impl From<bool> for ShiftMode {
 		} else {
 			ShiftMode::Disabled
 		}
-	}
-}
-
-impl Default for ShiftMode {
-	fn default() -> ShiftMode {
-		ShiftMode::Disabled
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
-#![cfg_attr(feature = "async", feature(generic_associated_types))]
 #![cfg_attr(feature = "async", feature(type_alias_impl_trait))]
-#![cfg_attr(feature = "async", feature(min_type_alias_impl_trait))]
+#![cfg_attr(feature = "async", feature(impl_trait_in_assoc_type))]
 
 use display_size::DisplaySize;
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};

--- a/src/non_blocking/bus/i2c.rs
+++ b/src/non_blocking/bus/i2c.rs
@@ -1,6 +1,6 @@
 use core::future::Future;
-use embassy_traits::delay::Delay;
-use embassy_traits::i2c::I2c;
+use embedded_hal_async::delay::DelayUs;
+use embedded_hal_async::i2c::I2c;
 
 use crate::error::Result;
 use crate::non_blocking::bus::DataBus;
@@ -15,14 +15,14 @@ const ENABLE: u8 = 0b0000_0100;
 // const READ_WRITE: u8 = 0b0000_0010; // Not used as no reading of the `HD44780` is done
 const REGISTER_SELECT: u8 = 0b0000_0001;
 
-impl<I2C: I2c> I2CBus<I2C> {
+impl<I2C: I2c<u8>> I2CBus<I2C> {
 	pub fn new(i2c_bus: I2C, address: u8) -> I2CBus<I2C> {
 		I2CBus { i2c_bus, address }
 	}
 
 	/// Write a nibble to the lcd
 	/// The nibble should be in the upper part of the byte
-	async fn write_nibble<'a, D: Delay + 'a>(&mut self, nibble: u8, data: bool, delay: &'a mut D) {
+	async fn write_nibble<'a, D: DelayUs + 'a>(&mut self, nibble: u8, data: bool, delay: &'a mut D) {
 		let rs = match data {
 			false => 0u8,
 			true => REGISTER_SELECT,
@@ -30,15 +30,15 @@ impl<I2C: I2c> I2CBus<I2C> {
 		let byte = nibble | rs | BACKLIGHT;
 
 		let _ = self.i2c_bus.write(self.address, &[byte, byte | ENABLE]).await;
-		delay.delay_ms(2u8 as u64).await;
+		delay.delay_ms(2).await;
 		let _ = self.i2c_bus.write(self.address, &[byte]).await;
 	}
 }
 
 impl<I2C: I2c + 'static> DataBus for I2CBus<I2C> {
-	type WriteFuture<'a, D: 'a> = impl Future<Output = Result<()>> + 'a;
+	type WriteFuture<'a, D: 'a + DelayUs> = impl Future<Output = Result<()>> + 'a;
 
-	fn write<'a, D: Delay + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::WriteFuture<'a, D> {
+	fn write<'a, D: DelayUs + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::WriteFuture<'a, D> {
 		async move {
 			let upper_nibble = byte & 0xF0;
 			self.write_nibble(upper_nibble, data, delay).await;

--- a/src/non_blocking/bus/mod.rs
+++ b/src/non_blocking/bus/mod.rs
@@ -1,5 +1,5 @@
 use core::future::Future;
-use embassy_traits::delay::Delay;
+use embedded_hal_async::delay::DelayUs;
 
 mod eightbit;
 mod fourbit;
@@ -12,9 +12,11 @@ pub use self::i2c::I2CBus;
 use crate::error::Result;
 
 pub trait DataBus {
-	type WriteFuture<'a, D: 'a>: Future<Output = Result<()>>;
+	type WriteFuture<'a, D: 'a + DelayUs>: Future<Output = Result<()>>
+	where
+		Self: 'a;
 
-	fn write<'a, D: Delay + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::WriteFuture<'a, D>;
+	fn write<'a, D: DelayUs + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::WriteFuture<'a, D>;
 
 	// TODO
 	// fn read(...)


### PR DESCRIPTION
embassy-traits have not made a release for 2 years, even though the embassy project has been expanding. As embassy now implements the embedded-hal-async traits, replacing embassy-traits with embedded-hal-async traits should be a drop-in replacement.

Also, embassy-traits does not even compile anymore on latest nightlies.

Summary of changes:
- Update dependency
- Update from `embassy_traits::delay::Delay` to `embedded_hal_async::delay::DelayUs`
- Update from `embassy_traits::i2c::I2c` to `embedded_hal_async::i2c::I2c`
- The Delay trait in embedded-hal-async is narrower than the one in embassy-traits. I do not know why there were `5u8 as u64` instances, but the embedded-hal trait only supports `u32`, so I removed all casts from the delay calls.
- The `min_type_alias_impl_trait` feature is not needed anymore
- The `impl_trait_in_assoc_type` feature is now required
- A constraint on the `DelayUs` trait was needed in `DataBus::WriteFuture` for the `D` parameter.
- ` where Self: 'a` is currently required on `DataBus::WriteFuture` to ensure that impls have maximum flexibility (See `rust-lang/rust#87479`)