### PR TITLE
Handle IO errors by propagation

### DIFF
--- a/src/bus/eightbit.rs
+++ b/src/bus/eightbit.rs
@@ -1,9 +1,9 @@
-use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
+use embedded_hal::{delay::DelayNs, digital};
 
 use crate::{
 	bus::DataBus,
-	error::{Error, Result},
+	error::{Error, Port, Result},
 };
 
 pub struct EightBitBus<
@@ -31,16 +31,17 @@ pub struct EightBitBus<
 }
 
 impl<
-		RS: OutputPin,
-		EN: OutputPin,
-		D0: OutputPin,
-		D1: OutputPin,
-		D2: OutputPin,
-		D3: OutputPin,
-		D4: OutputPin,
-		D5: OutputPin,
-		D6: OutputPin,
-		D7: OutputPin,
+		RS: OutputPin<Error = E>,
+		EN: OutputPin<Error = E>,
+		D0: OutputPin<Error = E>,
+		D1: OutputPin<Error = E>,
+		D2: OutputPin<Error = E>,
+		D3: OutputPin<Error = E>,
+		D4: OutputPin<Error = E>,
+		D5: OutputPin<Error = E>,
+		D6: OutputPin<Error = E>,
+		D7: OutputPin<Error = E>,
+		E,
 	> EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
 {
 	#[allow(clippy::too_many_arguments)]
@@ -59,7 +60,7 @@ impl<
 		EightBitBus { rs, en, d0, d1, d2, d3, d4, d5, d6, d7 }
 	}
 
-	fn set_bus_bits(&mut self, data: u8) -> Result<()> {
+	fn set_bus_bits(&mut self, data: u8) -> Result<(), E> {
 		let db0: bool = (0b0000_0001 & data) != 0;
 		let db1: bool = (0b0000_0010 & data) != 0;
 		let db2: bool = (0b0000_0100 & data) != 0;
@@ -69,86 +70,46 @@ impl<
 		let db6: bool = (0b0100_0000 & data) != 0;
 		let db7: bool = (0b1000_0000 & data) != 0;
 
-		if db0 {
-			self.d0.set_high().map_err(|_| Error)?;
-		} else {
-			self.d0.set_low().map_err(|_| Error)?;
-		}
-
-		if db1 {
-			self.d1.set_high().map_err(|_| Error)?;
-		} else {
-			self.d1.set_low().map_err(|_| Error)?;
-		}
-
-		if db2 {
-			self.d2.set_high().map_err(|_| Error)?;
-		} else {
-			self.d2.set_low().map_err(|_| Error)?;
-		}
-
-		if db3 {
-			self.d3.set_high().map_err(|_| Error)?;
-		} else {
-			self.d3.set_low().map_err(|_| Error)?;
-		}
-
-		if db4 {
-			self.d4.set_high().map_err(|_| Error)?;
-		} else {
-			self.d4.set_low().map_err(|_| Error)?;
-		}
-
-		if db5 {
-			self.d5.set_high().map_err(|_| Error)?;
-		} else {
-			self.d5.set_low().map_err(|_| Error)?;
-		}
-
-		if db6 {
-			self.d6.set_high().map_err(|_| Error)?;
-		} else {
-			self.d6.set_low().map_err(|_| Error)?;
-		}
-
-		if db7 {
-			self.d7.set_high().map_err(|_| Error)?;
-		} else {
-			self.d7.set_low().map_err(|_| Error)?;
-		}
+		self.d0.set_state(db0.into()).map_err(Error::wrap_io(Port::D0))?;
+		self.d1.set_state(db1.into()).map_err(Error::wrap_io(Port::D1))?;
+		self.d2.set_state(db2.into()).map_err(Error::wrap_io(Port::D2))?;
+		self.d3.set_state(db3.into()).map_err(Error::wrap_io(Port::D3))?;
+		self.d4.set_state(db4.into()).map_err(Error::wrap_io(Port::D4))?;
+		self.d5.set_state(db5.into()).map_err(Error::wrap_io(Port::D5))?;
+		self.d6.set_state(db6.into()).map_err(Error::wrap_io(Port::D6))?;
+		self.d7.set_state(db7.into()).map_err(Error::wrap_io(Port::D7))?;
 
 		Ok(())
 	}
 }
 
 impl<
-		RS: OutputPin,
-		EN: OutputPin,
-		D0: OutputPin,
-		D1: OutputPin,
-		D2: OutputPin,
-		D3: OutputPin,
-		D4: OutputPin,
-		D5: OutputPin,
-		D6: OutputPin,
-		D7: OutputPin,
+		RS: OutputPin<Error = E>,
+		EN: OutputPin<Error = E>,
+		D0: OutputPin<Error = E>,
+		D1: OutputPin<Error = E>,
+		D2: OutputPin<Error = E>,
+		D3: OutputPin<Error = E>,
+		D4: OutputPin<Error = E>,
+		D5: OutputPin<Error = E>,
+		D6: OutputPin<Error = E>,
+		D7: OutputPin<Error = E>,
+		E: digital::Error,
 	> DataBus for EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
 {
-	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<()> {
-		if data {
-			self.rs.set_high().map_err(|_| Error)?;
-		} else {
-			self.rs.set_low().map_err(|_| Error)?;
-		}
+	type Error = E;
+
+	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<(), Self::Error> {
+		self.rs.set_state(data.into()).map_err(Error::wrap_io(Port::RS))?;
 
 		self.set_bus_bits(byte)?;
 
-		self.en.set_high().map_err(|_| Error)?;
+		self.en.set_high().map_err(Error::wrap_io(Port::EN))?;
 		delay.delay_ms(2u32);
-		self.en.set_low().map_err(|_| Error)?;
+		self.en.set_low().map_err(Error::wrap_io(Port::EN))?;
 
 		if data {
-			self.rs.set_low().map_err(|_| Error)?;
+			self.rs.set_low().map_err(Error::wrap_io(Port::RS))?;
 		}
 
 		Ok(())

--- a/src/bus/i2c.rs
+++ b/src/bus/i2c.rs
@@ -1,6 +1,7 @@
 use embedded_hal::delay::DelayNs;
 use embedded_hal::i2c::I2c;
 
+use crate::error::{Error, Port};
 use crate::{bus::DataBus, error::Result};
 
 pub struct I2CBus<I2C> {
@@ -20,26 +21,28 @@ impl<I2C: I2c> I2CBus<I2C> {
 
 	/// Write a nibble to the lcd
 	/// The nibble should be in the upper part of the byte
-	fn write_nibble<D: DelayNs>(&mut self, nibble: u8, data: bool, delay: &mut D) {
+	fn write_nibble<D: DelayNs>(&mut self, nibble: u8, data: bool, delay: &mut D) -> Result<(), I2C::Error> {
 		let rs = match data {
 			false => 0u8,
 			true => REGISTER_SELECT,
 		};
 		let byte = nibble | rs | BACKLIGHT;
 
-		let _ = self.i2c_bus.write(self.address, &[byte, byte | ENABLE]);
+		self.i2c_bus.write(self.address, &[byte, byte | ENABLE]).map_err(Error::wrap_io(Port::I2C))?;
 		delay.delay_ms(2u32);
-		let _ = self.i2c_bus.write(self.address, &[byte]);
+		self.i2c_bus.write(self.address, &[byte]).map_err(Error::wrap_io(Port::I2C))
 	}
 }
 
 impl<I2C: I2c> DataBus for I2CBus<I2C> {
-	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<()> {
+	type Error = I2C::Error;
+
+	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<(), Self::Error> {
 		let upper_nibble = byte & 0xF0;
-		self.write_nibble(upper_nibble, data, delay);
+		self.write_nibble(upper_nibble, data, delay)?;
 
 		let lower_nibble = (byte & 0x0F) << 4;
-		self.write_nibble(lower_nibble, data, delay);
+		self.write_nibble(lower_nibble, data, delay)?;
 
 		Ok(())
 	}

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -11,7 +11,9 @@ pub use self::i2c::I2CBus;
 use crate::error::Result;
 
 pub trait DataBus {
-	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<()>;
+	type Error: core::fmt::Debug;
+
+	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<(), Self::Error>;
 
 	// TODO
 	// fn read(...)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,82 @@
+use core::convert::Infallible;
+
 #[derive(Debug)]
-pub struct Error;
-pub type Result<T> = core::result::Result<T, Error>;
+pub enum Error<IoE> {
+	/// Error related to IO of the MCU.
+	Io {
+		/// Which port (pin or interface) the error belongs to.
+		port: Port,
+		error: IoE,
+	},
+	/// Invalid coordinates on the display.
+	Position { position: (u8, u8), size: (u8, u8) },
+}
+
+impl<E> Error<E> {
+	pub(crate) const fn wrap_io(port: Port) -> impl FnOnce(E) -> Self {
+		move |error| Self::Io { port, error }
+	}
+
+	pub(crate) const fn from_non_io(error: Error<Infallible>) -> Self {
+		match error {
+			Error::Io { .. } => unreachable!(), // error is Infallible, which has no variants by definition
+			Error::Position { position, size } => Self::Position { position, size },
+		}
+	}
+}
+
+impl<E: core::fmt::Debug> core::fmt::Display for Error<E> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		match self {
+			Self::Io { port, error } => write!(f, "error on {port:?}: {error:?}"),
+			Self::Position { position, size } => write!(
+				f,
+				"coordinates out of bounds: ({};{}) not fitting in a {}x{} display",
+				position.0, position.1, size.0, size.1
+			),
+		}
+	}
+}
+
+impl<E: core::error::Error + 'static> core::error::Error for Error<E> {
+	fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+		match self {
+			Self::Io { error, .. } => Some(error),
+			_ => None,
+		}
+	}
+}
+
+pub type Result<T, E> = core::result::Result<T, Error<E>>;
+
+#[derive(Debug)]
+pub enum Port {
+	/// Pin `D0` of an [EightBitBus][`crate::bus::EightBitBus`].
+	D0,
+	/// Pin `D1` of an [EightBitBus][`crate::bus::EightBitBus`].
+	D1,
+	/// Pin `D2` of an [EightBitBus][`crate::bus::EightBitBus`].
+	D2,
+	/// Pin `D3` of an [EightBitBus][`crate::bus::EightBitBus`].
+	D3,
+	/// Pin `D4` of a [FourBitBus][`crate::bus::FourBitBus`] or
+	/// [EightBitBus][`crate::bus::EightBitBus`].
+	D4,
+	/// Pin `D5` of a [FourBitBus][`crate::bus::FourBitBus`] or
+	/// [EightBitBus][`crate::bus::EightBitBus`].
+	D5,
+	/// Pin `D6` of a [FourBitBus][`crate::bus::FourBitBus`] or
+	/// [EightBitBus][`crate::bus::EightBitBus`].
+	D6,
+	/// Pin `D7` of a [FourBitBus][`crate::bus::FourBitBus`] or
+	/// [EightBitBus][`crate::bus::EightBitBus`].
+	D7,
+	/// Pin `RS` of a [FourBitBus][`crate::bus::FourBitBus`] or
+	/// [EightBitBus][`crate::bus::EightBitBus`].
+	RS,
+	/// Pin `EN` of a [FourBitBus][`crate::bus::FourBitBus`] or
+	/// [EightBitBus][`crate::bus::EightBitBus`].
+	EN,
+	/// [I2CBus][`crate::bus::I2CBus`].
+	I2C,
+}

--- a/src/non_blocking/bus/eightbit.rs
+++ b/src/non_blocking/bus/eightbit.rs
@@ -1,9 +1,9 @@
 use core::future::Future;
-use embedded_hal::digital::OutputPin;
+use embedded_hal::digital::{self, OutputPin};
 use embedded_hal_async::delay::DelayNs;
 
 use crate::{
-	error::{Error, Result},
+	error::{Error, Port, Result},
 	non_blocking::bus::DataBus,
 };
 
@@ -32,18 +32,20 @@ pub struct EightBitBus<
 }
 
 impl<
-		RS: OutputPin,
-		EN: OutputPin,
-		D0: OutputPin,
-		D1: OutputPin,
-		D2: OutputPin,
-		D3: OutputPin,
-		D4: OutputPin,
-		D5: OutputPin,
-		D6: OutputPin,
-		D7: OutputPin,
+		RS: OutputPin<Error = E>,
+		EN: OutputPin<Error = E>,
+		D0: OutputPin<Error = E>,
+		D1: OutputPin<Error = E>,
+		D2: OutputPin<Error = E>,
+		D3: OutputPin<Error = E>,
+		D4: OutputPin<Error = E>,
+		D5: OutputPin<Error = E>,
+		D6: OutputPin<Error = E>,
+		D7: OutputPin<Error = E>,
+		E,
 	> EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
 {
+	#[allow(clippy::too_many_arguments)]
 	pub fn from_pins(
 		rs: RS,
 		en: EN,
@@ -59,7 +61,7 @@ impl<
 		EightBitBus { rs, en, d0, d1, d2, d3, d4, d5, d6, d7 }
 	}
 
-	fn set_bus_bits(&mut self, data: u8) -> Result<()> {
+	fn set_bus_bits(&mut self, data: u8) -> Result<(), E> {
 		let db0: bool = (0b0000_0001 & data) != 0;
 		let db1: bool = (0b0000_0010 & data) != 0;
 		let db2: bool = (0b0000_0100 & data) != 0;
@@ -69,87 +71,51 @@ impl<
 		let db6: bool = (0b0100_0000 & data) != 0;
 		let db7: bool = (0b1000_0000 & data) != 0;
 
-		if db0 {
-			self.d0.set_high().map_err(|_| Error)?;
-		} else {
-			self.d0.set_low().map_err(|_| Error)?;
-		}
-
-		if db1 {
-			self.d1.set_high().map_err(|_| Error)?;
-		} else {
-			self.d1.set_low().map_err(|_| Error)?;
-		}
-
-		if db2 {
-			self.d2.set_high().map_err(|_| Error)?;
-		} else {
-			self.d2.set_low().map_err(|_| Error)?;
-		}
-
-		if db3 {
-			self.d3.set_high().map_err(|_| Error)?;
-		} else {
-			self.d3.set_low().map_err(|_| Error)?;
-		}
-
-		if db4 {
-			self.d4.set_high().map_err(|_| Error)?;
-		} else {
-			self.d4.set_low().map_err(|_| Error)?;
-		}
-
-		if db5 {
-			self.d5.set_high().map_err(|_| Error)?;
-		} else {
-			self.d5.set_low().map_err(|_| Error)?;
-		}
-
-		if db6 {
-			self.d6.set_high().map_err(|_| Error)?;
-		} else {
-			self.d6.set_low().map_err(|_| Error)?;
-		}
-
-		if db7 {
-			self.d7.set_high().map_err(|_| Error)?;
-		} else {
-			self.d7.set_low().map_err(|_| Error)?;
-		}
+		self.d0.set_state(db0.into()).map_err(Error::wrap_io(Port::D0))?;
+		self.d1.set_state(db1.into()).map_err(Error::wrap_io(Port::D1))?;
+		self.d2.set_state(db2.into()).map_err(Error::wrap_io(Port::D2))?;
+		self.d3.set_state(db3.into()).map_err(Error::wrap_io(Port::D3))?;
+		self.d4.set_state(db4.into()).map_err(Error::wrap_io(Port::D4))?;
+		self.d5.set_state(db5.into()).map_err(Error::wrap_io(Port::D5))?;
+		self.d6.set_state(db6.into()).map_err(Error::wrap_io(Port::D6))?;
+		self.d7.set_state(db7.into()).map_err(Error::wrap_io(Port::D7))?;
 
 		Ok(())
 	}
 }
 
 impl<
-		RS: OutputPin + 'static,
-		EN: OutputPin + 'static,
-		D0: OutputPin + 'static,
-		D1: OutputPin + 'static,
-		D2: OutputPin + 'static,
-		D3: OutputPin + 'static,
-		D4: OutputPin + 'static,
-		D5: OutputPin + 'static,
-		D6: OutputPin + 'static,
-		D7: OutputPin + 'static,
+		RS: OutputPin<Error = E> + 'static,
+		EN: OutputPin<Error = E> + 'static,
+		D0: OutputPin<Error = E> + 'static,
+		D1: OutputPin<Error = E> + 'static,
+		D2: OutputPin<Error = E> + 'static,
+		D3: OutputPin<Error = E> + 'static,
+		D4: OutputPin<Error = E> + 'static,
+		D5: OutputPin<Error = E> + 'static,
+		D6: OutputPin<Error = E> + 'static,
+		D7: OutputPin<Error = E> + 'static,
+		E: digital::Error,
 	> DataBus for EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
 {
-	type WriteFuture<'a, D: 'a + DelayNs> = impl Future<Output = Result<()>> + 'a;
+	type Error = E;
+
+	type WriteFuture<'a, D: 'a + DelayNs> = impl Future<Output = Result<(), Self::Error>> + 'a;
 
 	fn write<'a, D: DelayNs + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::WriteFuture<'a, D> {
 		async move {
-			if data {
-				self.rs.set_high().map_err(|_| Error)?;
-			} else {
-				self.rs.set_low().map_err(|_| Error)?;
-			}
+			self.rs.set_state(data.into()).map_err(Error::wrap_io(Port::RS))?;
+
 			self.set_bus_bits(byte)?;
-			self.en.set_high().map_err(|_| Error)?;
+
+			self.en.set_high().map_err(Error::wrap_io(Port::EN))?;
 			delay.delay_ms(2).await;
-			self.en.set_low().map_err(|_| Error)?;
+			self.en.set_low().map_err(Error::wrap_io(Port::EN))?;
+
 			if data {
-				self.rs.set_low().map_err(|_| Error)?;
+				self.rs.set_low().map_err(Error::wrap_io(Port::RS))?;
 			}
+
 			Ok(())
 		}
 	}

--- a/src/non_blocking/bus/fourbit.rs
+++ b/src/non_blocking/bus/fourbit.rs
@@ -1,8 +1,8 @@
 use core::future::Future;
-use embedded_hal::digital::OutputPin;
+use embedded_hal::digital::{self, OutputPin};
 use embedded_hal_async::delay::DelayNs;
 
-use crate::error::{Error, Result};
+use crate::error::{Error, Port, Result};
 use crate::non_blocking::bus::DataBus;
 
 pub struct FourBitBus<RS: OutputPin, EN: OutputPin, D4: OutputPin, D5: OutputPin, D6: OutputPin, D7: OutputPin> {
@@ -14,110 +14,84 @@ pub struct FourBitBus<RS: OutputPin, EN: OutputPin, D4: OutputPin, D5: OutputPin
 	d7: D7,
 }
 
-impl<RS: OutputPin, EN: OutputPin, D4: OutputPin, D5: OutputPin, D6: OutputPin, D7: OutputPin>
-	FourBitBus<RS, EN, D4, D5, D6, D7>
+impl<
+		RS: OutputPin<Error = E>,
+		EN: OutputPin<Error = E>,
+		D4: OutputPin<Error = E>,
+		D5: OutputPin<Error = E>,
+		D6: OutputPin<Error = E>,
+		D7: OutputPin<Error = E>,
+		E,
+	> FourBitBus<RS, EN, D4, D5, D6, D7>
 {
 	pub fn from_pins(rs: RS, en: EN, d4: D4, d5: D5, d6: D6, d7: D7) -> FourBitBus<RS, EN, D4, D5, D6, D7> {
 		FourBitBus { rs, en, d4, d5, d6, d7 }
 	}
 
-	fn write_lower_nibble(&mut self, data: u8) -> Result<()> {
+	fn write_lower_nibble(&mut self, data: u8) -> Result<(), E> {
 		let db0: bool = (0b0000_0001 & data) != 0;
 		let db1: bool = (0b0000_0010 & data) != 0;
 		let db2: bool = (0b0000_0100 & data) != 0;
 		let db3: bool = (0b0000_1000 & data) != 0;
 
-		if db0 {
-			self.d4.set_high().map_err(|_| Error)?;
-		} else {
-			self.d4.set_low().map_err(|_| Error)?;
-		}
-
-		if db1 {
-			self.d5.set_high().map_err(|_| Error)?;
-		} else {
-			self.d5.set_low().map_err(|_| Error)?;
-		}
-
-		if db2 {
-			self.d6.set_high().map_err(|_| Error)?;
-		} else {
-			self.d6.set_low().map_err(|_| Error)?;
-		}
-
-		if db3 {
-			self.d7.set_high().map_err(|_| Error)?;
-		} else {
-			self.d7.set_low().map_err(|_| Error)?;
-		}
+		self.d4.set_state(db0.into()).map_err(Error::wrap_io(Port::D4))?;
+		self.d5.set_state(db1.into()).map_err(Error::wrap_io(Port::D5))?;
+		self.d6.set_state(db2.into()).map_err(Error::wrap_io(Port::D6))?;
+		self.d7.set_state(db3.into()).map_err(Error::wrap_io(Port::D7))?;
 
 		Ok(())
 	}
 
-	fn write_upper_nibble(&mut self, data: u8) -> Result<()> {
+	fn write_upper_nibble(&mut self, data: u8) -> Result<(), E> {
 		let db4: bool = (0b0001_0000 & data) != 0;
 		let db5: bool = (0b0010_0000 & data) != 0;
 		let db6: bool = (0b0100_0000 & data) != 0;
 		let db7: bool = (0b1000_0000 & data) != 0;
 
-		if db4 {
-			self.d4.set_high().map_err(|_| Error)?;
-		} else {
-			self.d4.set_low().map_err(|_| Error)?;
-		}
+		self.d4.set_state(db4.into()).map_err(Error::wrap_io(Port::D4))?;
+		self.d5.set_state(db5.into()).map_err(Error::wrap_io(Port::D5))?;
+		self.d6.set_state(db6.into()).map_err(Error::wrap_io(Port::D6))?;
+		self.d7.set_state(db7.into()).map_err(Error::wrap_io(Port::D7))?;
 
-		if db5 {
-			self.d5.set_high().map_err(|_| Error)?;
-		} else {
-			self.d5.set_low().map_err(|_| Error)?;
-		}
-
-		if db6 {
-			self.d6.set_high().map_err(|_| Error)?;
-		} else {
-			self.d6.set_low().map_err(|_| Error)?;
-		}
-
-		if db7 {
-			self.d7.set_high().map_err(|_| Error)?;
-		} else {
-			self.d7.set_low().map_err(|_| Error)?;
-		}
 		Ok(())
 	}
 }
 
 impl<
-		RS: OutputPin + 'static,
-		EN: OutputPin + 'static,
-		D4: OutputPin + 'static,
-		D5: OutputPin + 'static,
-		D6: OutputPin + 'static,
-		D7: OutputPin + 'static,
+		RS: OutputPin<Error = E> + 'static,
+		EN: OutputPin<Error = E> + 'static,
+		D4: OutputPin<Error = E> + 'static,
+		D5: OutputPin<Error = E> + 'static,
+		D6: OutputPin<Error = E> + 'static,
+		D7: OutputPin<Error = E> + 'static,
+		E: digital::Error,
 	> DataBus for FourBitBus<RS, EN, D4, D5, D6, D7>
 {
-	type WriteFuture<'a, D: 'a + DelayNs> = impl Future<Output = Result<()>> + 'a;
+	type Error = E;
+
+	type WriteFuture<'a, D: 'a + DelayNs> = impl Future<Output = Result<(), Self::Error>> + 'a;
 
 	fn write<'a, D: DelayNs + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::WriteFuture<'a, D> {
 		async move {
-			if data {
-				self.rs.set_high().map_err(|_| Error)?;
-			} else {
-				self.rs.set_low().map_err(|_| Error)?;
-			}
+			self.rs.set_state(data.into()).map_err(Error::wrap_io(Port::RS))?;
+
 			self.write_upper_nibble(byte)?;
+
 			// Pulse the enable pin to recieve the upper nibble
-			self.en.set_high().map_err(|_| Error)?;
+			self.en.set_high().map_err(Error::wrap_io(Port::EN))?;
 			delay.delay_ms(2).await;
-			self.en.set_low().map_err(|_| Error)?;
+			self.en.set_low().map_err(Error::wrap_io(Port::EN))?;
+
 			self.write_lower_nibble(byte)?;
 			// Pulse the enable pin to recieve the lower nibble
-			self.en.set_high().map_err(|_| Error)?;
+			self.en.set_high().map_err(Error::wrap_io(Port::EN))?;
 			delay.delay_ms(2).await;
-			self.en.set_low().map_err(|_| Error)?;
+			self.en.set_low().map_err(Error::wrap_io(Port::EN))?;
+
 			if data {
-				self.rs.set_low().map_err(|_| Error)?;
+				self.rs.set_low().map_err(Error::wrap_io(Port::RS))?;
 			}
+
 			Ok(())
 		}
 	}

--- a/src/non_blocking/bus/mod.rs
+++ b/src/non_blocking/bus/mod.rs
@@ -12,7 +12,9 @@ pub use self::i2c::I2CBus;
 use crate::error::Result;
 
 pub trait DataBus {
-	type WriteFuture<'a, D: 'a + DelayNs>: Future<Output = Result<()>>
+	type Error: core::fmt::Debug;
+
+	type WriteFuture<'a, D: 'a + DelayNs>: Future<Output = Result<(), Self::Error>>
 	where
 		Self: 'a;
 


### PR DESCRIPTION
I've added error handling to all IO operations (especially I2C). My motivation is that this would have saved my hours of debugging because I though that communication with my display was successful. I was unaware that the driver ignored any errors. My implementation propagates those errors to the user, which can then decide what to do with them (or keep ignoring).

I have only tested this on blocking I2C so far. I am very confident that this would work everywhere else, though I'd prefer to first test it on my display. Sadly, mine can only do I2C, though the other implementations didn't change much.

I'd be happy about any feedback on this. Especially because **this PR has some breaking changes** due to generics that have been added to the Error struct and many functions. Also, all pins must have the same error type with this implementation. It is technically possible to drop this requirement, but it would make the generics on Error explode.

### Example

Here's an example stack trace when unwrapping an Err result caused by me unplugging the CLK jumper. Previously, the program wouldn't have been able to notice this error as it would have been ignored and dropped by the driver.

```
====================== PANIC ======================
panicked at src/main.rs:46:35:
called `Result::unwrap()` on an `Err` value: Io { port: I2C, error: AckCheckFailed }

Backtrace:

0x400d0d96
0x400d0d96 - display_1602::__xtensa_lx_rt_main
    at ??:??
0x400d488e
0x400d488e - Reset
    at /home/colin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/xtensa-lx-rt-0.17.1/src/lib.rs:82
0x400d3f29
0x400d3f29 - ESP32Reset
    at /home/colin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-hal-0.20.1/src/soc/esp32/mod.rs:118
```