### PR TITLE
Custom Characters

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -1,0 +1,40 @@
+use core::iter::once;
+
+use embedded_hal::delay::DelayNs;
+
+use crate::{bus::DataBus, charset::CharsetWithFallback, error::Result, memory_map::DisplayMemoryMap, HD44780};
+
+pub struct CharacterDefinition {
+	pub pattern: [u8; 10],
+	pub cursor: u8,
+
+	// /// Since lines 12 to 16 are not used for display,
+	// /// they can be used for general data RAM.
+	// pub data: Option<[u8; 5]>,
+}
+
+impl<B, M, C> HD44780<B, M, C>
+where
+	B: DataBus,
+	M: DisplayMemoryMap,
+	C: CharsetWithFallback,
+{
+	pub fn define_custom_character<D: DelayNs>(
+		&mut self,
+		code: u8,
+		def: &CharacterDefinition,
+		delay: &mut D,
+	) -> Result<(), B::Error> {
+        self.write_command(0b01000000 | (code & 0b11) << 4, delay)?;
+        delay.delay_us(100);
+
+        let lines = def.pattern.iter().cloned().chain(once(def.cursor));
+        for line in lines {
+            self.write_byte(line, delay)?;
+        }
+
+        // Change back to DDRAM
+		self.set_cursor_pos(0, delay)?;
+		Ok(())
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use entry_mode::{CursorMode, EntryMode};
 pub mod setup;
 
 pub mod charset;
+pub mod character;
 
 pub mod memory_map;
 


### PR DESCRIPTION
This pull request allows defining custom characters. Closes #8.

This branch is currently based on #54 just for convenience, but I can rebase it onto the current version as it doesn't touch anything changed in that PR.

> ![photo_2024-09-17_06-44-15](https://github.com/user-attachments/assets/1fd13728-568c-4591-8bfe-9e364be7e955)
The custom character here is the diamond shape.

The current implementation has the drawback that it will reset the cursor position. This is required to change the writing mode from CHRAM back to DDRAM and we are currently not keeping track of the cursor position.

- [x] ~~It would be nice to have a second opinion on this. Should we keep track of the cursor or just accept resetting the position?~~
- [ ] Requires: #58 