### PR TITLE
Reading from the LCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ let mut lcd = HD44780::new(
     DisplayOptions8Bit::new(MemoryMap1602::new())
         .with_pins(FourBitBusPins {
             rs: d4.into_push_pull_output(&mut port), // Register Select pin,
+            rw: WriteOnlyMode,                       // Read/Write pin is pulled low,
             en: d3.into_push_pull_output(&mut port), // Enable pin,
 
             d4: d9.into_push_pull_output(&mut port),  // d4,
@@ -84,6 +85,7 @@ let mut display = HD44780::new(
     DisplayOptions8Bit::new(MemoryMap1602::new())
         .with_pins(FourBitBusPins {
             rs,
+            rw,
             en,
             d4,
             d5,

--- a/examples/atmega328-nostd/src/bin/hello-4bit.rs
+++ b/examples/atmega328-nostd/src/bin/hello-4bit.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::Delay;
+use embedded_hal::delay::DelayNs as _;
+use hd44780_driver::{
+	bus::{FourBitBusPins, WriteOnlyMode},
+	memory_map::MemoryMap1602,
+	setup::DisplayOptions4Bit,
+	HD44780,
+};
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+	let peripherals = arduino_hal::Peripherals::take().unwrap();
+	let pins = arduino_hal::pins!(peripherals);
+
+	// Setup USB Serial
+	let mut serial = arduino_hal::default_serial!(peripherals, pins, 115200);
+
+	let mut delay = Delay::new();
+
+	ufmt::uwriteln!(serial, "Start").unwrap();
+
+	// Configure LCD driver with 10 pins
+	let options = DisplayOptions4Bit::new(MemoryMap1602::new()).with_pins(FourBitBusPins {
+		rs: pins.d12.into_output(),
+		rw: WriteOnlyMode,
+		en: pins.d11.into_output(),
+
+		d4: pins.d6.into_opendrain(),
+		d5: pins.d5.into_opendrain(),
+		d6: pins.d4.into_opendrain(),
+		d7: pins.d3.into_opendrain(),
+	});
+
+	// Initialize LCD driver
+	// Note: IO Error is infallible, thus unwrapping won't panic here
+	let mut display = HD44780::new(options, &mut delay).unwrap_or_else(|_| unreachable!());
+
+	display.clear(&mut delay).unwrap();
+	display.reset(&mut delay).unwrap();
+
+	display.write_str("Hello, world!", &mut delay).unwrap();
+
+	loop {
+		delay.delay_ms(1000);
+	}
+}

--- a/examples/atmega328-nostd/src/bin/hello-8bit.rs
+++ b/examples/atmega328-nostd/src/bin/hello-8bit.rs
@@ -1,0 +1,49 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::Delay;
+use embedded_hal::delay::DelayNs as _;
+use hd44780_driver::{bus::{EightBitBusPins, WriteOnlyMode}, memory_map::MemoryMap1602, setup::DisplayOptions8Bit, HD44780};
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+	let peripherals = arduino_hal::Peripherals::take().unwrap();
+	let pins = arduino_hal::pins!(peripherals);
+
+	// Setup USB Serial
+	let mut serial = arduino_hal::default_serial!(peripherals, pins, 115200);
+
+	let mut delay = Delay::new();
+
+	ufmt::uwriteln!(serial, "Start").unwrap();
+
+	// Configure LCD driver with 10 pins
+	let options = DisplayOptions8Bit::new(MemoryMap1602::new()).with_pins(EightBitBusPins {
+		rs: pins.d12.into_output(),
+		rw: WriteOnlyMode,
+		en: pins.d11.into_output(),
+
+		d0: pins.d10.into_opendrain(),
+		d1: pins.d9.into_opendrain(),
+		d2: pins.d8.into_opendrain(),
+		d3: pins.d7.into_opendrain(),
+		d4: pins.d6.into_opendrain(),
+		d5: pins.d5.into_opendrain(),
+		d6: pins.d4.into_opendrain(),
+		d7: pins.d3.into_opendrain(),
+	});
+
+	// Initialize LCD driver
+	// Note: IO Error is infallible, thus unwrapping won't panic here
+	let mut display = HD44780::new(options, &mut delay).unwrap_or_else(|_| unreachable!());
+
+	display.clear(&mut delay).unwrap();
+	display.reset(&mut delay).unwrap();
+
+	display.write_str("Hello, world!", &mut delay).unwrap();
+
+	loop {
+		delay.delay_ms(1000);
+	}
+}

--- a/examples/atmega328-nostd/src/bin/read-i2c.rs
+++ b/examples/atmega328-nostd/src/bin/read-i2c.rs
@@ -1,0 +1,51 @@
+#![no_std]
+#![no_main]
+
+use arduino_hal::Delay;
+use embedded_hal::delay::DelayNs as _;
+use hd44780_driver::{memory_map::MemoryMap1602, setup::DisplayOptionsI2C, HD44780};
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+	let peripherals = arduino_hal::Peripherals::take().unwrap();
+	let pins = arduino_hal::pins!(peripherals);
+
+	// Setup USB Serial
+	let mut serial = arduino_hal::default_serial!(peripherals, pins, 115200);
+
+	let mut delay = Delay::new();
+
+	ufmt::uwriteln!(serial, "Start\r").unwrap();
+
+	// Configure I2C interface
+	let i2c =
+		arduino_hal::I2c::new(peripherals.TWI, pins.a4.into_pull_up_input(), pins.a5.into_pull_up_input(), 100_000);
+
+	// Configure LCD driver with I2C
+	let mut options = DisplayOptionsI2C::new(MemoryMap1602::new()).with_i2c_bus(i2c, 0x27);
+
+	// Initialize LCD driver
+	let mut display = loop {
+		match HD44780::new(options, &mut delay) {
+			Err((options_back, error)) => {
+				ufmt::uwriteln!(serial, "Error creating LCD Driver: {}", error).unwrap();
+				options = options_back;
+				delay.delay_ms(500);
+				// try again
+			}
+			Ok(display) => break display,
+		}
+	};
+
+	display.clear(&mut delay).unwrap();
+	display.reset(&mut delay).unwrap();
+
+	display.write_str("Hello, world!", &mut delay).unwrap();
+	let status = display.read_status(&mut delay).unwrap();
+	ufmt::uwriteln!(serial, "{:?}\r", status).unwrap();
+
+	loop {
+		delay.delay_ms(1000);
+	}
+}

--- a/examples/esp32-nostd/src/bin/charset-4bit.rs
+++ b/examples/esp32-nostd/src/bin/charset-4bit.rs
@@ -12,8 +12,11 @@ use esp_hal::{
 	system::SystemControl,
 };
 use hd44780_driver::{
-	bus::FourBitBusPins, charset::CharsetA00, memory_map::MemoryMap1602, setup::DisplayOptions4Bit, Cursor,
-	CursorBlink, Direction, Display, DisplayMode, HD44780,
+	bus::{FourBitBusPins, WriteOnlyMode},
+	charset::CharsetA00,
+	memory_map::MemoryMap1602,
+	setup::DisplayOptions4Bit,
+	Cursor, CursorBlink, Direction, Display, DisplayMode, HD44780,
 };
 use log::{error, info};
 
@@ -33,6 +36,7 @@ fn main() -> ! {
 	let mut options = DisplayOptions4Bit::new(MemoryMap1602::new())
 		.with_pins(FourBitBusPins {
 			rs: make_output(io.pins.gpio12),
+			rw: WriteOnlyMode,
 			en: make_output(io.pins.gpio14),
 
 			d4: make_output(io.pins.gpio17),

--- a/examples/esp32-nostd/src/bin/charset-8bit.rs
+++ b/examples/esp32-nostd/src/bin/charset-8bit.rs
@@ -12,8 +12,11 @@ use esp_hal::{
 	system::SystemControl,
 };
 use hd44780_driver::{
-	bus::EightBitBusPins, charset::CharsetA00, memory_map::MemoryMap1602, setup::DisplayOptions8Bit, Cursor,
-	CursorBlink, Direction, Display, DisplayMode, HD44780,
+	bus::{EightBitBusPins, WriteOnlyMode},
+	charset::CharsetA00,
+	memory_map::MemoryMap1602,
+	setup::DisplayOptions8Bit,
+	Cursor, CursorBlink, Direction, Display, DisplayMode, HD44780,
 };
 use log::{error, info};
 
@@ -33,6 +36,7 @@ fn main() -> ! {
 	let mut options = DisplayOptions8Bit::new(MemoryMap1602::new())
 		.with_pins(EightBitBusPins {
 			rs: make_output(io.pins.gpio12),
+			rw: WriteOnlyMode,
 			en: make_output(io.pins.gpio14),
 
 			d0: make_output(io.pins.gpio2),

--- a/examples/esp32-nostd/src/bin/hello-4bit.rs
+++ b/examples/esp32-nostd/src/bin/hello-4bit.rs
@@ -11,7 +11,12 @@ use esp_hal::{
 	prelude::*,
 	system::SystemControl,
 };
-use hd44780_driver::{bus::FourBitBusPins, memory_map::MemoryMap1602, setup::DisplayOptions4Bit, HD44780};
+use hd44780_driver::{
+	bus::{FourBitBusPins, WriteOnlyMode},
+	memory_map::MemoryMap1602,
+	setup::DisplayOptions4Bit,
+	HD44780,
+};
 use log::{error, info};
 
 #[entry]
@@ -29,6 +34,7 @@ fn main() -> ! {
 	// Configure LCD driver with 6 pins
 	let mut options = DisplayOptions4Bit::new(MemoryMap1602::new()).with_pins(FourBitBusPins {
 		rs: make_output(io.pins.gpio12),
+		rw: WriteOnlyMode,
 		en: make_output(io.pins.gpio14),
 
 		d4: make_output(io.pins.gpio17),

--- a/examples/esp32-nostd/src/bin/hello-8bit.rs
+++ b/examples/esp32-nostd/src/bin/hello-8bit.rs
@@ -11,7 +11,12 @@ use esp_hal::{
 	prelude::*,
 	system::SystemControl,
 };
-use hd44780_driver::{bus::EightBitBusPins, memory_map::MemoryMap1602, setup::DisplayOptions8Bit, HD44780};
+use hd44780_driver::{
+	bus::{EightBitBusPins, WriteOnlyMode},
+	memory_map::MemoryMap1602,
+	setup::DisplayOptions8Bit,
+	HD44780,
+};
 use log::{error, info};
 
 #[entry]
@@ -29,6 +34,7 @@ fn main() -> ! {
 	// Configure LCD driver with 10 pins
 	let mut options = DisplayOptions8Bit::new(MemoryMap1602::new()).with_pins(EightBitBusPins {
 		rs: make_output(io.pins.gpio12),
+		rw: WriteOnlyMode,
 		en: make_output(io.pins.gpio14),
 
 		d0: make_output(io.pins.gpio2),

--- a/src/bus/eightbit.rs
+++ b/src/bus/eightbit.rs
@@ -2,7 +2,7 @@ use embedded_hal::digital::OutputPin;
 use embedded_hal::{delay::DelayNs, digital};
 
 use crate::{
-	bus::DataBus,
+	bus::WritableDataBus,
 	error::{Error, Port, Result},
 };
 
@@ -95,7 +95,7 @@ impl<
 		D6: OutputPin<Error = E>,
 		D7: OutputPin<Error = E>,
 		E: digital::Error,
-	> DataBus for EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
+	> WritableDataBus for EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
 {
 	type Error = E;
 
@@ -141,7 +141,7 @@ mod non_blocking {
 			D6: OutputPin<Error = E> + 'static,
 			D7: OutputPin<Error = E> + 'static,
 			E: digital::Error,
-		> DataBus for EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
+		> WritableDataBus for EightBitBus<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
 	{
 		type Error = E;
 

--- a/src/bus/fourbit.rs
+++ b/src/bus/fourbit.rs
@@ -1,7 +1,7 @@
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{self, OutputPin};
 
-use crate::bus::DataBus;
+use crate::bus::WritableDataBus;
 use crate::error::{Error, Port, Result};
 
 #[derive(Debug, Clone, Copy)]
@@ -74,7 +74,7 @@ impl<
 		D6: OutputPin<Error = E>,
 		D7: OutputPin<Error = E>,
 		E: digital::Error,
-	> DataBus for FourBitBus<RS, EN, D4, D5, D6, D7>
+	> WritableDataBus for FourBitBus<RS, EN, D4, D5, D6, D7>
 {
 	type Error = E;
 
@@ -124,7 +124,7 @@ mod non_blocking {
 			D6: OutputPin<Error = E> + 'static,
 			D7: OutputPin<Error = E> + 'static,
 			E: digital::Error,
-		> DataBus for FourBitBus<RS, EN, D4, D5, D6, D7>
+		> WritableDataBus for FourBitBus<RS, EN, D4, D5, D6, D7>
 	{
 		type Error = E;
 

--- a/src/bus/i2c.rs
+++ b/src/bus/i2c.rs
@@ -92,15 +92,16 @@ impl<I2C: I2c> ReadableDataBus for I2CBus<I2C> {
 #[cfg(feature = "async")]
 mod non_blocking {
 	use core::future::Future;
+	use embedded_hal::i2c::Operation;
 	use embedded_hal_async::delay::DelayNs;
 	use embedded_hal_async::i2c::I2c;
 
 	use crate::{
 		error::{Error, Port, Result},
-		non_blocking::bus::DataBus,
+		non_blocking::bus::{ReadableDataBus, WritableDataBus},
 	};
 
-	use super::{I2CBus, BACKLIGHT, ENABLE, REGISTER_SELECT};
+	use super::{I2CBus, BACKLIGHT, ENABLE, READ, REGISTER_SELECT};
 
 	impl<I2C: I2c> I2CBus<I2C> {
 		/// Write a nibble to the lcd
@@ -121,19 +122,39 @@ mod non_blocking {
 			delay.delay_ms(2).await;
 			self.i2c_bus.write(self.address, &[byte]).await.map_err(Error::wrap_io(Port::I2C))
 		}
+
+		async fn read_nibble_non_blocking<'a, D: DelayNs + 'a>(
+			&mut self,
+			data: bool,
+			delay: &'a mut D,
+		) -> Result<u8, I2C::Error> {
+			let rs = match data {
+				false => 0u8,
+				true => REGISTER_SELECT,
+			};
+			let byte = 0b11110000 | READ | BACKLIGHT | rs;
+
+			let mut read_byte = 0;
+			self.i2c_bus.write(self.address, &[byte, byte | ENABLE]).await.map_err(Error::wrap_io(Port::I2C))?;
+			delay.delay_ms(2u32).await;
+			self.i2c_bus
+				.transaction(
+					self.address,
+					&mut [Operation::Read(core::slice::from_mut(&mut read_byte)), Operation::Write(&[byte])],
+				)
+				.await
+				.map_err(Error::wrap_io(Port::I2C))?;
+
+			Ok(read_byte)
+		}
 	}
 
 	impl<I2C: I2c + 'static> WritableDataBus for I2CBus<I2C> {
 		type Error = I2C::Error;
 
-		type WriteFuture<'a, D: 'a + DelayNs> = impl Future<Output = Result<(), Self::Error>> + 'a;
+		type Future<'a, D: 'a + DelayNs> = impl Future<Output = Result<(), Self::Error>> + 'a;
 
-		fn write<'a, D: DelayNs + 'a>(
-			&'a mut self,
-			byte: u8,
-			data: bool,
-			delay: &'a mut D,
-		) -> Self::WriteFuture<'a, D> {
+		fn write<'a, D: DelayNs + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::Future<'a, D> {
 			async move {
 				let upper_nibble = byte & 0xF0;
 				self.write_nibble_non_blocking(upper_nibble, data, delay).await?;
@@ -142,6 +163,21 @@ mod non_blocking {
 				self.write_nibble_non_blocking(lower_nibble, data, delay).await?;
 
 				Ok(())
+			}
+		}
+	}
+
+	impl<I2C: I2c + 'static> ReadableDataBus for I2CBus<I2C> {
+		type Error = I2C::Error;
+
+		type Future<'a, D: 'a + DelayNs> = impl Future<Output = Result<u8, Self::Error>> + 'a;
+
+		fn read<'a, D: DelayNs + 'a>(&'a mut self, data: bool, delay: &'a mut D) -> Self::Future<'a, D> {
+			async move {
+				let upper_nibble = self.read_nibble_non_blocking(data, delay).await?;
+				let lower_nibble = self.read_nibble_non_blocking(data, delay).await?;
+
+				Ok((upper_nibble & 0xF0) | (lower_nibble >> 4))
 			}
 		}
 	}

--- a/src/bus/i2c.rs
+++ b/src/bus/i2c.rs
@@ -1,8 +1,10 @@
 use embedded_hal::delay::DelayNs;
-use embedded_hal::i2c::I2c;
+use embedded_hal::i2c::{I2c, Operation};
 
 use crate::error::{Error, Port};
-use crate::{bus::DataBus, error::Result};
+use crate::{bus::WritableDataBus, error::Result};
+
+use super::ReadableDataBus;
 
 pub struct I2CBus<I2C> {
 	i2c_bus: I2C,
@@ -11,7 +13,7 @@ pub struct I2CBus<I2C> {
 
 const BACKLIGHT: u8 = 0b0000_1000;
 const ENABLE: u8 = 0b0000_0100;
-// const READ_WRITE: u8 = 0b0000_0010; // Not used as no reading of the `HD44780` is done
+const READ: u8 = 0b0000_0010;
 const REGISTER_SELECT: u8 = 0b0000_0001;
 
 impl<I2C> I2CBus<I2C> {
@@ -38,9 +40,31 @@ impl<I2C: I2c> I2CBus<I2C> {
 		delay.delay_ms(2u32);
 		self.i2c_bus.write(self.address, &[byte]).map_err(Error::wrap_io(Port::I2C))
 	}
+
+	/// Read a nibble from the lcd
+	/// The nibble will be in the upper part of the byte
+	fn read_nibble<D: DelayNs>(&mut self, data: bool, delay: &mut D) -> Result<u8, I2C::Error> {
+		let rs = match data {
+			false => 0u8,
+			true => REGISTER_SELECT,
+		};
+		let byte = 0b11110000 | READ | BACKLIGHT | rs;
+
+		let mut read_byte = 0;
+		self.i2c_bus.write(self.address, &[byte, byte | ENABLE]).map_err(Error::wrap_io(Port::I2C))?;
+		delay.delay_ms(2u32);
+		self.i2c_bus
+			.transaction(
+				self.address,
+				&mut [Operation::Read(core::slice::from_mut(&mut read_byte)), Operation::Write(&[byte])],
+			)
+			.map_err(Error::wrap_io(Port::I2C))?;
+
+		Ok(read_byte)
+	}
 }
 
-impl<I2C: I2c> DataBus for I2CBus<I2C> {
+impl<I2C: I2c> WritableDataBus for I2CBus<I2C> {
 	type Error = I2C::Error;
 
 	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<(), Self::Error> {
@@ -51,6 +75,17 @@ impl<I2C: I2c> DataBus for I2CBus<I2C> {
 		self.write_nibble(lower_nibble, data, delay)?;
 
 		Ok(())
+	}
+}
+
+impl<I2C: I2c> ReadableDataBus for I2CBus<I2C> {
+	type Error = I2C::Error;
+
+	fn read<D: DelayNs>(&mut self, data: bool, delay: &mut D) -> Result<u8, Self::Error> {
+		let upper_nibble = self.read_nibble(data, delay)?;
+		let lower_nibble = self.read_nibble(data, delay)?;
+
+		Ok((upper_nibble & 0xF0) | (lower_nibble >> 4))
 	}
 }
 
@@ -88,7 +123,7 @@ mod non_blocking {
 		}
 	}
 
-	impl<I2C: I2c + 'static> DataBus for I2CBus<I2C> {
+	impl<I2C: I2c + 'static> WritableDataBus for I2CBus<I2C> {
 		type Error = I2C::Error;
 
 		type WriteFuture<'a, D: 'a + DelayNs> = impl Future<Output = Result<(), Self::Error>> + 'a;

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -1,4 +1,5 @@
 use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::OutputPin;
 
 mod eightbit;
 mod fourbit;
@@ -9,6 +10,7 @@ pub use self::fourbit::{FourBitBus, FourBitBusPins};
 pub use self::i2c::I2CBus;
 
 use crate::error::Result;
+use crate::sealed::Internal;
 
 pub trait WritableDataBus {
 	type Error: core::fmt::Debug;
@@ -20,4 +22,57 @@ pub trait ReadableDataBus {
 	type Error: core::fmt::Debug;
 
 	fn read<D: DelayNs>(&mut self, data: bool, delay: &mut D) -> Result<u8, Self::Error>;
+}
+
+mod sealed {
+	use crate::sealed::Internal;
+
+	#[doc(hidden)]
+	pub trait SealedWriteSelect<E>: Sized {
+		fn select_write(&mut self, _: Internal) -> Result<(), E>;
+	}
+
+	#[doc(hidden)]
+	pub trait SealedReadSelect<E>: Sized {
+		fn select_read(&mut self, _: Internal) -> Result<(), E>;
+	}
+}
+
+pub trait WriteSelect<E>: sealed::SealedWriteSelect<E> {}
+pub trait ReadSelect<E>: sealed::SealedReadSelect<E> {}
+
+impl<P> WriteSelect<P::Error> for P where P: OutputPin {}
+impl<P> ReadSelect<P::Error> for P where P: OutputPin {}
+
+impl<P> sealed::SealedWriteSelect<P::Error> for P
+where
+	P: OutputPin,
+{
+	fn select_write(&mut self, _: Internal) -> core::result::Result<(), P::Error> {
+		self.set_low()
+	}
+}
+
+impl<P> sealed::SealedReadSelect<P::Error> for P
+where
+	P: OutputPin,
+{
+	fn select_read(&mut self, _: Internal) -> core::result::Result<(), P::Error> {
+		self.set_high()
+	}
+}
+
+/// This can be used instead of a pin for RW in four and eight bit bus configurations
+/// to specify that the RW pin of the LCD has been pulled low permanently.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
+pub struct WriteOnlyMode;
+
+impl<E> WriteSelect<E> for WriteOnlyMode {}
+
+impl<E> sealed::SealedWriteSelect<E> for WriteOnlyMode {
+	fn select_write(&mut self, _: Internal) -> core::result::Result<(), E> {
+		Ok(())
+	}
 }

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -10,11 +10,14 @@ pub use self::i2c::I2CBus;
 
 use crate::error::Result;
 
-pub trait DataBus {
+pub trait WritableDataBus {
 	type Error: core::fmt::Debug;
 
 	fn write<D: DelayNs>(&mut self, byte: u8, data: bool, delay: &mut D) -> Result<(), Self::Error>;
+}
 
-	// TODO
-	// fn read(...)
+pub trait ReadableDataBus {
+	type Error: core::fmt::Debug;
+
+	fn read<D: DelayNs>(&mut self, data: bool, delay: &mut D) -> Result<u8, Self::Error>;
 }

--- a/src/display_status.rs
+++ b/src/display_status.rs
@@ -1,0 +1,24 @@
+use embedded_hal::delay::DelayNs;
+
+use crate::{bus::ReadableDataBus, charset::CharsetWithFallback, error::Result, memory_map::DisplayMemoryMap, HD44780};
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
+pub struct DisplayStatus {
+	pub busy: bool,
+	pub address: u8,
+}
+
+impl<B, M, C> HD44780<B, M, C>
+where
+	B: ReadableDataBus,
+	M: DisplayMemoryMap,
+	C: CharsetWithFallback,
+{
+	pub fn read_status<D: DelayNs>(&mut self, delay: &mut D) -> Result<DisplayStatus, B::Error> {
+		let status_byte = self.bus.read(false, delay)?;
+
+		Ok(DisplayStatus { busy: status_byte & 0x80 > 0, address: status_byte & 0x7f })
+	}
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,9 @@ pub enum Port {
 	/// Pin `RS` of a [FourBitBus][`crate::bus::FourBitBus`] or
 	/// [EightBitBus][`crate::bus::EightBitBus`].
 	RS,
+	/// Pin `RW` of a [FourBitBus][`crate::bus::FourBitBus`] or
+	/// [EightBitBus][`crate::bus::EightBitBus`].
+	RW,
 	/// Pin `EN` of a [FourBitBus][`crate::bus::FourBitBus`] or
 	/// [EightBitBus][`crate::bus::EightBitBus`].
 	EN,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use display_size::DisplaySize;
 use embedded_hal::delay::DelayNs;
 
 pub mod bus;
-use bus::DataBus;
+use bus::WritableDataBus;
 
 pub mod error;
 use error::{Error, Result};
@@ -24,6 +24,7 @@ pub mod memory_map;
 
 pub mod display_mode;
 pub mod display_size;
+pub mod display_status;
 
 pub use display_mode::DisplayMode;
 use memory_map::DisplayMemoryMap;
@@ -33,7 +34,7 @@ use setup::blocking::DisplayOptions;
 #[cfg(feature = "async")]
 pub mod non_blocking;
 
-pub struct HD44780<B: DataBus, M: DisplayMemoryMap, C: CharsetWithFallback> {
+pub struct HD44780<B, M: DisplayMemoryMap, C: CharsetWithFallback> {
 	bus: B,
 	memory_map: M,
 	charset: C,
@@ -65,7 +66,7 @@ pub enum CursorBlink {
 
 impl<B, M, C> HD44780<B, M, C>
 where
-	B: DataBus,
+	B: WritableDataBus,
 	M: DisplayMemoryMap,
 	C: CharsetWithFallback,
 {

--- a/src/non_blocking/bus.rs
+++ b/src/non_blocking/bus.rs
@@ -7,15 +7,22 @@ pub use crate::bus::{FourBitBus, FourBitBusPins};
 
 use crate::error::Result;
 
-pub trait DataBus {
+pub trait WritableDataBus {
 	type Error: core::fmt::Debug;
 
-	type WriteFuture<'a, D: 'a + DelayNs>: Future<Output = Result<(), Self::Error>>
+	type Future<'a, D: 'a + DelayNs>: Future<Output = Result<(), Self::Error>>
 	where
 		Self: 'a;
 
-	fn write<'a, D: DelayNs + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::WriteFuture<'a, D>;
+	fn write<'a, D: DelayNs + 'a>(&'a mut self, byte: u8, data: bool, delay: &'a mut D) -> Self::Future<'a, D>;
+}
 
-	// TODO
-	// fn read(...)
+pub trait ReadableDataBus {
+	type Error: core::fmt::Debug;
+
+	type Future<'a, D: 'a + DelayNs>: Future<Output = Result<u8, Self::Error>>
+	where
+		Self: 'a;
+
+	fn read<'a, D: DelayNs + 'a>(&'a mut self, data: bool, delay: &'a mut D) -> Self::Future<'a, D>;
 }

--- a/src/non_blocking/mod.rs
+++ b/src/non_blocking/mod.rs
@@ -4,7 +4,7 @@
 use embedded_hal_async::delay::DelayNs;
 
 pub mod bus;
-use bus::DataBus;
+use bus::WritableDataBus;
 
 use crate::charset::CharsetWithFallback;
 use crate::display_size::DisplaySize;
@@ -22,7 +22,7 @@ pub use crate::display_mode;
 
 pub use display_mode::DisplayMode;
 
-pub struct HD44780<B: DataBus, M: DisplayMemoryMap, C: CharsetWithFallback> {
+pub struct HD44780<B: WritableDataBus, M: DisplayMemoryMap, C: CharsetWithFallback> {
 	bus: B,
 	memory_map: M,
 	charset: C,
@@ -39,7 +39,7 @@ use self::error::Error;
 
 impl<B, M, C> HD44780<B, M, C>
 where
-	B: DataBus,
+	B: WritableDataBus,
 	M: DisplayMemoryMap,
 	C: CharsetWithFallback,
 {

--- a/src/non_blocking/mod.rs
+++ b/src/non_blocking/mod.rs
@@ -22,8 +22,8 @@ pub use crate::display_mode;
 
 pub use display_mode::DisplayMode;
 
-pub struct HD44780<B: WritableDataBus, M: DisplayMemoryMap, C: CharsetWithFallback> {
-	bus: B,
+pub struct HD44780<B, M: DisplayMemoryMap, C: CharsetWithFallback> {
+	pub(crate) bus: B,
 	memory_map: M,
 	charset: C,
 	entry_mode: EntryMode,

--- a/src/setup/blocking.rs
+++ b/src/setup/blocking.rs
@@ -6,7 +6,7 @@ use embedded_hal::{
 use sealed::SealedDisplayOptions;
 
 use crate::{
-	bus::{DataBus, EightBitBus, FourBitBus, I2CBus},
+	bus::{EightBitBus, FourBitBus, I2CBus, WritableDataBus},
 	charset::CharsetWithFallback,
 	entry_mode::EntryMode,
 	error::{Error, Result},
@@ -20,13 +20,13 @@ use super::{DisplayOptions4Bit, DisplayOptions8Bit, DisplayOptionsI2C};
 pub(crate) mod sealed {
 	use embedded_hal::delay::DelayNs;
 
-	use crate::{bus::DataBus, charset::CharsetWithFallback, memory_map::DisplayMemoryMap, sealed::Internal};
+	use crate::{bus::WritableDataBus, charset::CharsetWithFallback, memory_map::DisplayMemoryMap, sealed::Internal};
 
 	use super::DisplayOptionsResult;
 
 	#[doc(hidden)]
 	pub trait SealedDisplayOptions: Sized {
-		type Bus: DataBus;
+		type Bus: WritableDataBus;
 		type MemoryMap: DisplayMemoryMap;
 		type Charset: CharsetWithFallback;
 		type IoError: core::fmt::Debug;
@@ -164,7 +164,11 @@ impl<M: DisplayMemoryMap, C: CharsetWithFallback, I2C: I2c> SealedDisplayOptions
 }
 
 // Follow the 8-bit setup procedure as specified in the HD44780 datasheet
-fn init_8bit<B: DataBus, D: DelayNs>(bus: &mut B, entry_mode: &EntryMode, delay: &mut D) -> Result<(), B::Error> {
+fn init_8bit<B: WritableDataBus, D: DelayNs>(
+	bus: &mut B,
+	entry_mode: &EntryMode,
+	delay: &mut D,
+) -> Result<(), B::Error> {
 	// Wait for the LCD to wakeup if it was off
 	delay.delay_ms(15u32);
 
@@ -206,7 +210,11 @@ fn init_8bit<B: DataBus, D: DelayNs>(bus: &mut B, entry_mode: &EntryMode, delay:
 	Ok(())
 }
 
-fn init_4bit<B: DataBus, D: DelayNs>(bus: &mut B, entry_mode: &EntryMode, delay: &mut D) -> Result<(), B::Error> {
+fn init_4bit<B: WritableDataBus, D: DelayNs>(
+	bus: &mut B,
+	entry_mode: &EntryMode,
+	delay: &mut D,
+) -> Result<(), B::Error> {
 	// Wait for the LCD to wakeup if it was off
 	delay.delay_ms(15u32);
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -15,23 +15,23 @@ pub(crate) mod non_blocking;
 pub struct Unspecified;
 
 #[derive(Debug, Clone, Copy)]
-pub struct DisplayOptions8Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D0, D1, D2, D3, D4, D5, D6, D7> {
+pub struct DisplayOptions8Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, RW, EN, D0, D1, D2, D3, D4, D5, D6, D7> {
 	/// Memory map used for mapping 2D coordinates to the display.
 	pub memory_map: M,
 	/// The character set this display uses.
 	pub charset: C,
 	pub entry_mode: EntryMode,
-	pub pins: EightBitBusPins<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>,
+	pub pins: EightBitBusPins<RS, RW, EN, D0, D1, D2, D3, D4, D5, D6, D7>,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct DisplayOptions4Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D4, D5, D6, D7> {
+pub struct DisplayOptions4Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, RW, EN, D4, D5, D6, D7> {
 	/// Memory map used for mapping 2D coordinates to the display.
 	pub memory_map: M,
 	/// The character set this display uses.
 	pub charset: C,
 	pub entry_mode: EntryMode,
-	pub pins: FourBitBusPins<RS, EN, D4, D5, D6, D7>,
+	pub pins: FourBitBusPins<RS, RW, EN, D4, D5, D6, D7>,
 }
 
 pub struct DisplayOptionsI2C<M: DisplayMemoryMap, C: CharsetWithFallback, I2C> {
@@ -58,6 +58,7 @@ impl<M: DisplayMemoryMap>
 		Unspecified,
 		Unspecified,
 		Unspecified,
+		Unspecified,
 	>
 {
 	pub fn new(memory_map: M) -> Self {
@@ -67,6 +68,7 @@ impl<M: DisplayMemoryMap>
 			entry_mode: EntryMode::default(),
 			pins: EightBitBusPins {
 				rs: Unspecified,
+				rw: Unspecified,
 				en: Unspecified,
 				d0: Unspecified,
 				d1: Unspecified,
@@ -91,6 +93,7 @@ impl<M: DisplayMemoryMap>
 		Unspecified,
 		Unspecified,
 		Unspecified,
+		Unspecified,
 	>
 {
 	pub fn new(memory_map: M) -> Self {
@@ -100,6 +103,7 @@ impl<M: DisplayMemoryMap>
 			entry_mode: EntryMode::default(),
 			pins: FourBitBusPins {
 				rs: Unspecified,
+				rw: Unspecified,
 				en: Unspecified,
 				d4: Unspecified,
 				d5: Unspecified,
@@ -153,12 +157,12 @@ macro_rules! builder_functions {
 	};
 }
 
-builder_functions!(DisplayOptions8Bit < RS, EN, D0, D1, D2, D3, D4, D5, D6, D7 > { pins });
-builder_functions!(DisplayOptions4Bit < RS, EN, D4, D5, D6, D7 > { pins });
+builder_functions!(DisplayOptions8Bit < RS, RW, EN, D0, D1, D2, D3, D4, D5, D6, D7 > { pins });
+builder_functions!(DisplayOptions4Bit < RS, RW, EN, D4, D5, D6, D7 > { pins });
 builder_functions!(DisplayOptionsI2C<I2C> { i2c_bus, address });
 
-impl<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
-	DisplayOptions8Bit<M, C, RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
+impl<M: DisplayMemoryMap, C: CharsetWithFallback, RS, RW, EN, D0, D1, D2, D3, D4, D5, D6, D7>
+	DisplayOptions8Bit<M, C, RS, RW, EN, D0, D1, D2, D3, D4, D5, D6, D7>
 {
 	/// The eight d0..d7 pins are used to send and recieve with
 	/// the `HD44780`.
@@ -166,16 +170,17 @@ impl<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D0, D1, D2, D3, D4, D5
 	/// if incoming data is a command or data.
 	/// The enable pin `en` is used to tell the `HD44780` that there
 	/// is data on the 8 data pins and that it should read them in.
-	pub fn with_pins<RS2, EN2, D02, D12, D22, D32, D42, D52, D62, D72>(
+	#[allow(clippy::type_complexity)] // there is no way around this
+	pub fn with_pins<RS2, RW2, EN2, D02, D12, D22, D32, D42, D52, D62, D72>(
 		self,
-		pins: EightBitBusPins<RS2, EN2, D02, D12, D22, D32, D42, D52, D62, D72>,
-	) -> DisplayOptions8Bit<M, C, RS2, EN2, D02, D12, D22, D32, D42, D52, D62, D72> {
+		pins: EightBitBusPins<RS2, RW2, EN2, D02, D12, D22, D32, D42, D52, D62, D72>,
+	) -> DisplayOptions8Bit<M, C, RS2, RW2, EN2, D02, D12, D22, D32, D42, D52, D62, D72> {
 		DisplayOptions8Bit { memory_map: self.memory_map, charset: self.charset, entry_mode: self.entry_mode, pins }
 	}
 }
 
-impl<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D4, D5, D6, D7>
-	DisplayOptions4Bit<M, C, RS, EN, D4, D5, D6, D7>
+impl<M: DisplayMemoryMap, C: CharsetWithFallback, RS, RW, EN, D4, D5, D6, D7>
+	DisplayOptions4Bit<M, C, RS, RW, EN, D4, D5, D6, D7>
 {
 	/// The four d4..d7 pins are used to send and recieve with
 	/// the `HD44780`.
@@ -183,10 +188,10 @@ impl<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D4, D5, D6, D7>
 	/// if incoming data is a command or data.
 	/// The enable pin `en` is used to tell the `HD44780` that there
 	/// is data on the 4 data pins and that it should read them in.
-	pub fn with_pins<RS2, EN2, D42, D52, D62, D72>(
+	pub fn with_pins<RS2, RW2, EN2, D42, D52, D62, D72>(
 		self,
-		pins: FourBitBusPins<RS2, EN2, D42, D52, D62, D72>,
-	) -> DisplayOptions4Bit<M, C, RS2, EN2, D42, D52, D62, D72> {
+		pins: FourBitBusPins<RS2, RW2, EN2, D42, D52, D62, D72>,
+	) -> DisplayOptions4Bit<M, C, RS2, RW2, EN2, D42, D52, D62, D72> {
 		DisplayOptions4Bit { memory_map: self.memory_map, charset: self.charset, entry_mode: self.entry_mode, pins }
 	}
 }


### PR DESCRIPTION
I'm working on the implementations for reading data from the display. ~~For now, I've only implemented it for blocking I2C.~~ To do this, I split `DataBus` into two traits for reading and writing because depending on the pin configuration, reading may not be possible (and is not required for basic operation).

## Notable Changes

- `rw` pin was added to 4/8-bit bus pin structs. Instead of a pin, `WriteOnlyMode` can be specified to opt-out of read features. This requires pulling the RW pin low on the display. **This is a breaking change**, but easy to adapt.
- `DataBus` trait was split into Read* and Write* traits.
- Added `read_status`