### PR TITLE
Remove debug bound on pin generics

### DIFF
--- a/src/bus/eightbit.rs
+++ b/src/bus/eightbit.rs
@@ -6,7 +6,7 @@ use crate::{
 	error::{Error, Port, Result},
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct EightBitBusPins<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7> {
 	pub rs: RS,
 	pub en: EN,
@@ -18,6 +18,14 @@ pub struct EightBitBusPins<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7> {
 	pub d5: D5,
 	pub d6: D6,
 	pub d7: D7,
+}
+
+impl<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7> core::fmt::Debug
+	for EightBitBusPins<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
+{
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		f.debug_struct("EightBitBusPins").finish()
+	}
 }
 
 #[derive(Debug)]

--- a/src/bus/fourbit.rs
+++ b/src/bus/fourbit.rs
@@ -1,10 +1,11 @@
 use embedded_hal::delay::DelayNs;
+use core::fmt::Debug;
 use embedded_hal::digital::{self, OutputPin};
 
 use crate::bus::DataBus;
 use crate::error::{Error, Port, Result};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct FourBitBusPins<RS, EN, D4, D5, D6, D7> {
 	pub rs: RS,
 	pub en: EN,
@@ -12,6 +13,12 @@ pub struct FourBitBusPins<RS, EN, D4, D5, D6, D7> {
 	pub d5: D5,
 	pub d6: D6,
 	pub d7: D7,
+}
+
+impl<RS, EN, D4, D5, D6, D7> Debug for FourBitBusPins<RS, EN, D4, D5, D6, D7> {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		f.debug_struct("FourBitBusPins").finish()
+	}
 }
 
 #[derive(Debug)]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod non_blocking;
 #[derive(Debug, Clone, Copy)]
 pub struct Unspecified;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct DisplayOptions8Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D0, D1, D2, D3, D4, D5, D6, D7> {
 	/// Memory map used for mapping 2D coordinates to the display.
 	pub memory_map: M,
@@ -24,7 +24,23 @@ pub struct DisplayOptions8Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, E
 	pub pins: EightBitBusPins<RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>,
 }
 
-#[derive(Debug, Clone, Copy)]
+impl<M, C, RS, EN, D0, D1, D2, D3, D4, D5, D6, D7> core::fmt::Debug
+	for DisplayOptions8Bit<M, C, RS, EN, D0, D1, D2, D3, D4, D5, D6, D7>
+where
+	M: DisplayMemoryMap + core::fmt::Debug,
+	C: CharsetWithFallback + core::fmt::Debug,
+{
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("DisplayOptions4Bit")
+			.field("memory_map", &self.memory_map)
+			.field("charset", &self.charset)
+			.field("entry_mode", &self.entry_mode)
+			.field("pins", &self.pins)
+			.finish()
+	}
+}
+
+#[derive(Clone, Copy)]
 pub struct DisplayOptions4Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, EN, D4, D5, D6, D7> {
 	/// Memory map used for mapping 2D coordinates to the display.
 	pub memory_map: M,
@@ -32,6 +48,21 @@ pub struct DisplayOptions4Bit<M: DisplayMemoryMap, C: CharsetWithFallback, RS, E
 	pub charset: C,
 	pub entry_mode: EntryMode,
 	pub pins: FourBitBusPins<RS, EN, D4, D5, D6, D7>,
+}
+
+impl<M, C, RS, EN, D4, D5, D6, D7> core::fmt::Debug for DisplayOptions4Bit<M, C, RS, EN, D4, D5, D6, D7>
+where
+	M: DisplayMemoryMap + core::fmt::Debug,
+	C: CharsetWithFallback + core::fmt::Debug,
+{
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("DisplayOptions4Bit")
+			.field("memory_map", &self.memory_map)
+			.field("charset", &self.charset)
+			.field("entry_mode", &self.entry_mode)
+			.field("pins", &self.pins)
+			.finish()
+	}
 }
 
 pub struct DisplayOptionsI2C<M: DisplayMemoryMap, C: CharsetWithFallback, I2C> {


### PR DESCRIPTION
The previous auto-implementation automatically added `Debug` bounds on all pin instances. However, not every HAL might have a debug implementation on the pin structures.

I think it would be better for this library if the pins do not have that bound. It makes the library easier to use, because each time those bounds are violated, I have to fork a HAL and add the debug bound manually (which can be non-trivial, e.g. in the case of the Raspberry Pi Pico HAL). I am a big fan of adding the Debug bound on every public structure in my libraries, but I think in this case the advantages of losing a little bit of information (not that much, the user can still see whether it is a 4 or 8 pin bus) and increase the flexibility of the library are worth it.