### PR TITLE
Update lib.rs to add a public command interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ where
 		self.write_byte(self.charset.code_from_utf8_with_fallback(data), delay)
 	}
 
-	fn write_command<D: DelayNs>(&mut self, cmd: u8, delay: &mut D) -> Result<(), B::Error> {
+	pub fn write_command<D: DelayNs>(&mut self, cmd: u8, delay: &mut D) -> Result<(), B::Error> {
 		self.bus.write(cmd, false, delay)?;
 
 		// Wait for the command to be processed


### PR DESCRIPTION
Made write_command public. This allows for the user to do something like `display.write_command(0x0C, &mut delay);` to remove the cursor icon from the screen. Naturally users should be careful with raw commands, but I feel that there is more benefit than risk with this change.